### PR TITLE
Update vc-shortcode-autoloader.php

### DIFF
--- a/wp-content/plugins/js_composer/include/autoload/vc-shortcode-autoloader.php
+++ b/wp-content/plugins/js_composer/include/autoload/vc-shortcode-autoloader.php
@@ -45,11 +45,7 @@ class VcShortcodeAutoloader {
 	 */
 	public static function includeClass( $class ) {
 		$class = strtolower( $class );
-		$files = array();
-
-		if ( self::$config['classmap'] ) {
-			$files = isset( self::$config['classmap'][ $class ] ) ? self::$config['classmap'][ $class ] : array();
-		}
+		$files = isset( self::$config['classmap'][ $class ] ) ? self::$config['classmap'][ $class ] : array();
 
 		if ( $files ) {
 			foreach ( $files as $k => $file ) {


### PR DESCRIPTION
Removed additional if statement to line 67 as unrequired.
The shorthand for isset does what the original code intended. i.e. if self::$config['classmap'][ $class ] is the same as isset(self::$config['classmap'][ $class ]). If it does not exist then isset will fail, as will isset fail if it does exist but is null.